### PR TITLE
Rename artifact to sbt-git-versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**git-versioning-sbt-plugin** is an sbt plugin designed to make maintaining a simple, consistent, and accurate
+**sbt-git-versioning** is an sbt plugin designed to make maintaining a simple, consistent, and accurate
  [semantic versioning](http://semver.org/spec/v2.0.0.html) scheme with as little manual labor as possible.
 
 There are two sbt plugins in this one plugin library:
@@ -24,16 +24,16 @@ Alternatively, you can add the following (if you want to use Maven style resolut
 ```
 In either case, you should now be able to add the plugin dependency to `project/plugins.sbt`:
 ```scala
-  addSbtPlugin("com.rallyhealth.sbt" % "git-versioning-sbt-plugin" % "x.y.z")
+  addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "x.y.z")
 ```
 3. Enable the plugin and set `semVerLimit` in `build.sbt` (see
- [below](https://github.com/rallyhealth/git-versioning-sbt-plugin#semverlimit)
+ [below](https://github.com/rallyhealth/sbt-git-versioning#semverlimit)
  for details)
 
 ```scala
 val example = project
   .enablePlugins(SemVerPlugin)
-  // See https://github.com/rallyhealth/git-versioning-sbt-plugin#semverlimit
+  // See https://github.com/rallyhealth/sbt-git-versioning#semverlimit
   .settings(semVerLimit := "x.y.z")
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 sbtPlugin := true
 
-name := "git-versioning-sbt-plugin"
+name := "sbt-git-versioning"
 organizationName := "Rally Health"
 organization := "com.rallyhealth.sbt"
 

--- a/src/main/scala/com/rallyhealth/sbt/scripted/ScriptedUtils.scala
+++ b/src/main/scala/com/rallyhealth/sbt/scripted/ScriptedUtils.scala
@@ -12,7 +12,7 @@ import scala.util.Try
   * Implementation of the various assert-style methods that are used by the "test" script. This uses a
   * [[BufferedLog]] as the source of the data that this will assert against.
   *
-  * This class lives within the `git-versioning-sbt-plugin` project and not in the `scripted` test code because IntelliJ
+  * This class lives within the `sbt-git-versioning` project and not in the `scripted` test code because IntelliJ
   * correctly recognizes these files, unlike the files within the `scripted` test code.
   */
 object ScriptedUtils {

--- a/src/main/scala/com/rallyhealth/sbt/semver/SemVerPlugin.scala
+++ b/src/main/scala/com/rallyhealth/sbt/semver/SemVerPlugin.scala
@@ -114,7 +114,7 @@ object SemVerPlugin extends AutoPlugin {
      * WARNING to anyone who might think "This doesn't need Def.taskDyn {}" YES IT DOES -- I've written this at least a
      * dozen different ways trying to remove Def.taskDyn {} and it doesn't work. This might compile, it might run, but
      * it won't run correctly in ALL cases. This means it might run semVerCheck() more than once, which sucks, but that's
-     * FAAAR better than not running at all. If you do change this YOU MUST RUN git-versioning-sbt-plugin-test/checkSemver.sh
+     * FAAAR better than not running at all. If you do change this YOU MUST RUN sbt-git-versioning-test/checkSemver.sh
      * because that will check all the different scenarios.
      *
      * I use Def.taskDyn {} here because otherwise the conditional actually doesn't do anything. Even though it looks


### PR DESCRIPTION
@htmldoug pointed out that the naming convention for sbt plugins is to start with `sbt-` and not contain the word `plugin`

@rcmurphy @usufruct99 