### PR TITLE
Add support for mima problem filters

### DIFF
--- a/src/main/scala/com/rallyhealth/sbt/semver/SemVerPlugin.scala
+++ b/src/main/scala/com/rallyhealth/sbt/semver/SemVerPlugin.scala
@@ -196,7 +196,7 @@ object SemVerPlugin extends AutoPlugin {
 
     MiMa.miMaChecker := {
       val classpath = (fullClasspath in MimaKeys.mimaFindBinaryIssues).value
-      new MimaChecker(MiMaExecutor(classpath, streams.value))
+      new MimaChecker(MiMaExecutor(classpath, streams.value), MimaKeys.mimaBinaryIssueFilters.value)
     },
 
     MiMa.moduleResolver := new IvyModuleResolver(scalaModuleInfo.value, ivySbt.value, streams.value),

--- a/src/sbt-test/semver/filters/.gitignore
+++ b/src/sbt-test/semver/filters/.gitignore
@@ -1,0 +1,19 @@
+### Scala template
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+global/
+pending*
+
+# RallyScriptedPlugin
+scriptedOutput-*

--- a/src/sbt-test/semver/filters/build.sbt
+++ b/src/sbt-test/semver/filters/build.sbt
@@ -1,0 +1,11 @@
+import com.typesafe.tools.mima.core._
+
+scalaVersion in ThisBuild := "2.11.12"
+
+organization in ThisBuild := "com.rallyhealth.test.scripted"
+
+logLevel := sbt.Level.Info
+
+enablePlugins(SemVerPlugin)
+
+mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("Thing")

--- a/src/sbt-test/semver/filters/project/plugins.sbt
+++ b/src/sbt-test/semver/filters/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+        |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  else addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % pluginVersion)
+}

--- a/src/sbt-test/semver/filters/src/main/scala/Thing.scala
+++ b/src/sbt-test/semver/filters/src/main/scala/Thing.scala
@@ -1,0 +1,4 @@
+class Thing {
+
+  def foo: String = "foo"
+}

--- a/src/sbt-test/semver/filters/test
+++ b/src/sbt-test/semver/filters/test
@@ -1,0 +1,18 @@
+# Set up a git repo appease GitVersioningPlugin and tag first version.
+$ exec git init
+$ exec git add .
+$ exec git commit -am 'Initial commit.'
+$ exec git tag v1.0.0
+
+# Publish the first version so that SemVer will have a baseline to compare to.
+> publishLocal
+
+# Introduce breaking change. It shouldn't care because it is filtered out.
+$ exec git rm src/main/scala/Thing.scala
+$ exec git commit -am 'Breaking change.'
+
+# Reload to have the new commit reflected in the version. Should be 1.0.1-1-hash-SNAPSHOT.
+> reload
+
+# SemVerCheck should pass here.
+> semVerCheck


### PR DESCRIPTION
This pull request adds support for the `mimaBinaryIssueFilters` setting provided by the sbt-mima plugin. This is useful for example to exclude internal implementation details from the compatibility checks.