### PR TITLE
Publish to Sonatype / Maven Central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,12 @@ scala:
   - 2.12.6
 jdk:
   - openjdk8
+
+before_script:
+  # Download sbt because Travis can't find it automatically :(
+  - mkdir -p $HOME/.sbt/launchers/1.2.8/
+  - curl -L -o $HOME/.sbt/launchers/1.2.8/sbt-launch.jar https://repo1.maven.org/maven2/org/scala-sbt/sbt-launch/1.2.8/sbt-launch-1.2.8.jar
+
 script:
   - sbt ^test ^scripted
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,10 @@
 import sbt.plugins.SbtPlugin
 
 name := "sbt-git-versioning"
-organizationName := "Rally Health"
-organization := "com.rallyhealth.sbt"
+ThisBuild / organizationName := "Rally Health"
+ThisBuild / organization := "com.rallyhealth.sbt"
 
-licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
-
-bintrayOrganization := Some("rallyhealth")
-bintrayRepository := "sbt-plugins"
+ThisBuild / licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 
 // SbtPlugin requires sbt 1.2.0+
 // See: https://developer.lightbend.com/blog/2018-07-02-sbt-1-2-0/#sbtplugin-for-plugin-development

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,5 @@ resolvers += Resolver.url(
   url("https://dl.bintray.com/rallyhealth/sbt-plugins"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.3.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.0")
+

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,17 @@
+// Your profile name of the sonatype account. The default is the same with the organization value
+sonatypeProfileName := "com.rallyhealth"
+
+// To sync with Maven central, you need to supply the following information:
+publishMavenStyle := true
+
+// publish to Maven Central
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
+ThisBuild / publishTo := Some {
+  if (isSnapshot.value)
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/snapshots"))
+  else
+    Resolver.url("Sonatype", url("https://s01.oss.sonatype.org/content/repositories/releases"))
+}
+
+import xerial.sbt.Sonatype.GitHubHosting
+sonatypeProjectHosting := Some(GitHubHosting("rallyhealth", "sbt-git-versioning", "jeff.n.may@gmail.com"))


### PR DESCRIPTION
Bintray is shutting down on May 1st. I'm moving this to Maven Central in its current form so that older projects that still depend on this plugin can migrate to this version on Maven Central.