### PR TITLE
Use version 1.6.0 for sbt-git-versioning

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += Resolver.url(
   "Rally Plugin Releases",
   url("https://dl.bintray.com/rallyhealth/sbt-plugins"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.3.0")
+addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.6.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.0")
 


### PR DESCRIPTION
1.3.0 is not possible to download from Bintray any more, so it was
impossible to build if you did not have it cached.