### PR TITLE
Add Support for 'Extra Identifier' Releases 

### DIFF
--- a/src/main/scala/com/rallyhealth/sbt/versioning/GitDriver.scala
+++ b/src/main/scala/com/rallyhealth/sbt/versioning/GitDriver.scala
@@ -42,7 +42,12 @@ trait GitDriver {
         headVersion
 
       case GitBranchStateOneReleaseNotHead(head, _, version) =>
-        SnapshotVersion.createAfterRelease(version, head)
+        SemanticVersion.fromString(head.commit.tags.mkString) match {
+          case Some(preReleaseVersion) =>
+            preReleaseVersion
+          case _ =>
+            SnapshotVersion.createAfterRelease(version.toRelease, head)
+        }
 
       case GitBranchStateOneReleaseHead(_, version) =>
         version

--- a/src/main/scala/com/rallyhealth/sbt/versioning/LowerBoundedSemanticVersion.scala
+++ b/src/main/scala/com/rallyhealth/sbt/versioning/LowerBoundedSemanticVersion.scala
@@ -33,6 +33,8 @@ object LowerBoundedSemanticVersion {
       )
 
       if (lowerBoundedVersion > version) {
+        if (version.isRelease && version.versionIdentifiers.values.exists(v => StringSemVerIdentifier.regex.pattern.matcher(v.toString).matches()))
+          return version
         require(version.isSnapshot, s"gitVersioningSnapshotLowerBound=$bound is higher than release=$version. Refusing to do a release build.")
         lowerBoundedVersion
       } else version

--- a/src/main/scala/com/rallyhealth/sbt/versioning/SemVerReleaseType.scala
+++ b/src/main/scala/com/rallyhealth/sbt/versioning/SemVerReleaseType.scala
@@ -59,7 +59,7 @@ object SemVerReleaseType {
           // Snapshot versions are already incremented as a patch over the previous version
           originalVersion match {
             case rv: ReleaseVersion => v.copy(patch = v.patch + 1)
-            case sv: SnapshotVersion => v
+            case _                  => v
           }
       }
     }

--- a/src/test/scala/com/rallyhealth/sbt/versioning/SemanticVersionSpec.scala
+++ b/src/test/scala/com/rallyhealth/sbt/versioning/SemanticVersionSpec.scala
@@ -281,25 +281,25 @@ class SemanticVersionSpec extends FunSpec {
         }
 
         it("with identifier") {
-          val version = fromString("v1.2.3-rc1").get.asInstanceOf[ReleaseVersion]
+          val version = fromString("v1.2.3-rc1").get.asInstanceOf[PreReleaseVersion]
           assert(version.toString === "1.2.3-rc1")
           assert(version.major === 1, version)
           assert(version.minor === 2, version)
           assert(version.patch === 3, version)
           assert(!version.isDirty, version)
           assert(version.identifiers.values.map(_.toString) === Seq("rc1"))
-          assert(ReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
+          assert(PreReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
         }
 
         it("with multiple identifiers") {
-          val version = fromString("v1.2.3-rc1-beta").get.asInstanceOf[ReleaseVersion]
+          val version = fromString("v1.2.3-rc1-beta").get.asInstanceOf[PreReleaseVersion]
           assert(version.toString === "1.2.3-rc1-beta")
           assert(version.major === 1, version)
           assert(version.minor === 2, version)
           assert(version.patch === 3, version)
           assert(!version.isDirty, version)
           assert(version.identifiers.values.map(_.toString) === Seq("rc1", "beta"))
-          assert(ReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
+          assert(PreReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
         }
       }
 
@@ -328,25 +328,25 @@ class SemanticVersionSpec extends FunSpec {
         }
 
         it("with identifier") {
-          val version = fromString("v1.2.3-rc1-dirty-SNAPSHOT").get.asInstanceOf[ReleaseVersion]
+          val version = fromString("v1.2.3-rc1-dirty-SNAPSHOT").get.asInstanceOf[PreReleaseVersion]
           assert(version.toString === "1.2.3-rc1-dirty-SNAPSHOT")
           assert(version.major === 1, version)
           assert(version.minor === 2, version)
           assert(version.patch === 3, version)
           assert(version.isDirty, version)
           assert(version.identifiers.values.map(_.toString) === Seq("rc1", "dirty", "SNAPSHOT"))
-          assert(ReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
+          assert(PreReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
         }
 
         it("with multiple identifiers") {
-          val version = fromString("v1.2.3-rc1-beta-dirty-SNAPSHOT").get.asInstanceOf[ReleaseVersion]
+          val version = fromString("v1.2.3-rc1-beta-dirty-SNAPSHOT").get.asInstanceOf[PreReleaseVersion]
           assert(version.toString === "1.2.3-rc1-beta-dirty-SNAPSHOT")
           assert(version.major === 1, version)
           assert(version.minor === 2, version)
           assert(version.patch === 3, version)
           assert(version.isDirty, version)
           assert(version.identifiers.values.map(_.toString) === Seq("rc1", "beta", "dirty", "SNAPSHOT"))
-          assert(ReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
+          assert(PreReleaseVersion.regex.pattern.matcher(version.toString).matches, version.toString)
         }
       }
     }
@@ -678,7 +678,9 @@ class SemanticVersionSpec extends FunSpec {
           "1.0.0-rc.1",
           "1.0.0")
 
-        val origOrder = fromDocs.flatMap(str => ReleaseVersion.unapply(str))
+        val origOrder: Seq[SemanticVersion] = fromDocs.flatMap(str =>
+          PreReleaseVersion.unapply(str) orElse ReleaseVersion.unapply(str)
+        )
 
         assert(fromDocs.size === origOrder.size)
 


### PR DESCRIPTION
This feature enables users to produce "extra-identifier" builds, such as RCs for testing. Here's an example of creating SemVer-compliant RCs using the new functionality:

1. Partway through a patch release cycle, there are 32 commits in this SnapshotVersion: `1.7.0-32-b324c0e3-SNAPSHOT`
2. Commit change(s) then exec `git tag v1.7.0-rc.1` creates this version: `1.7.0-rc.1`
    * Note: "Exta identified" / PreRelease builds do not contain commit count or commit hash, like a standard Release build.
3. Commit change(s): `1.7.0-34-7b63a9a9-SNAPSHOT`
    * Note: commit count is retained after a RC release.
4. Commit change(s) then exec `git tag v1.7.0-rc.2` creates this PreReleaseVersion: `1.7.0-rc.2`
5. Commit change(s) then exec `git tag v1.7.0` creates this ReleaseVersion: `1.7.0`
6. Increment `gitSnapshotLowerBound` patch level in the repo, then commit change: `1.7.1-1-cc5c1b9e-SNAPSHOT`
    * Note: The commit count is reset per SemVer spec for incrementing patches.
